### PR TITLE
Add resolver for aws worker types

### DIFF
--- a/src/resolvers/WorkerTypes.js
+++ b/src/resolvers/WorkerTypes.js
@@ -43,5 +43,8 @@ export default {
     workerTypes(parent, { provisionerId, connection, filter }, { loaders }) {
       return loaders.workerTypes.load({ provisionerId, connection, filter });
     },
+    awsProvisionerWorkerTypeSummaries(parent, args, { loaders }) {
+      return loaders.awsProvisionerWorkerTypeSummaries.load({});
+    },
   },
 };


### PR DESCRIPTION
This is needed to get pending and running capacities for aws-provisioner worker types.