### PR TITLE
Add ability to get pending tasks when fetching aws worker types

### DIFF
--- a/src/graphql/AwsProvisionerWorkerTypes.graphql
+++ b/src/graphql/AwsProvisionerWorkerTypes.graphql
@@ -184,6 +184,8 @@ type AwsProvisionerWorkerTypeSummary {
   requestedCapacity: Int!
   pendingCapacity: Int!
   runningCapacity: Int!
+
+  pendingTasks: Int!
 }
 
 type AwsProvisionerWorkerTypeState {

--- a/src/resolvers/AwsProvisionerWorkerTypes.js
+++ b/src/resolvers/AwsProvisionerWorkerTypes.js
@@ -50,6 +50,14 @@ export default {
     INSTANCE_REQUEST: 'instance-request',
     TERMINATION: 'termination',
   },
+  AwsProvisionerWorkerTypeSummary: {
+    pendingTasks({ workerType }, args, { loaders }) {
+      return loaders.pendingTasks.load({
+        provisionerId: 'aws-provisioner-v1',
+        workerType,
+      });
+    },
+  },
   Query: {
     awsProvisionerWorkerType(parent, { workerType }, { loaders }) {
       return loaders.awsProvisionerWorkerType.load(workerType);


### PR DESCRIPTION
This is particularly useful for the aws-provisioner view in order to fetch the list of worker types with their respective pending tasks number in a single request.