### PR TITLE
Make provisionerId of type String instead of ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.swp
 *.log
 .env
+.idea

--- a/src/graphql/CachePurges.graphql
+++ b/src/graphql/CachePurges.graphql
@@ -1,6 +1,6 @@
 type CachePurge {
   # ProvisionerId associated with the workerType.
-  provisionerId: ID!
+  provisionerId: String!
 
   # Workertype cache exists on.
   workerType: String!
@@ -18,7 +18,7 @@ input PurgeCacheInput {
 }
 
 type PurgeCache {
-  provisionerId: ID
+  provisionerId: String
   workerType: ID
 }
 
@@ -43,5 +43,5 @@ extend type Mutation {
   # Publish a purge-cache message to purge caches in payload with `cacheName`
   # for a `provisionerId` and `workerType`. Workers should be listening for
   # this message and purge caches when they see it.
-  purgeCache(provisionerId: ID!, workerType: ID!, payload: PurgeCacheInput): PurgeCache
+  purgeCache(provisionerId: String!, workerType: ID!, payload: PurgeCacheInput): PurgeCache
 }

--- a/src/graphql/Hooks.graphql
+++ b/src/graphql/Hooks.graphql
@@ -13,7 +13,7 @@ input HookMetadataInput {
 }
 
 type HookTask {
-  provisionerId: ID!
+  provisionerId: String!
   workerType: String!
   schedulerId: ID
   taskGroupId: ID

--- a/src/graphql/Provisioners.graphql
+++ b/src/graphql/Provisioners.graphql
@@ -27,15 +27,15 @@ type ProvisionerAction {
 }
 
 type Provisioner {
-  provisionerId: ID!
+  provisionerId: String!
   stability: ProvisionerStability!
   description: String!
   expires: DateTime!
   lastDateActive: DateTime!
   actions: [ProvisionerAction]!
 
-  workerTypes(provisionerId: ID = provisionerId, connection: PageConnection, filter: JSON): WorkerTypesConnection
-  workerType(provisionerId: ID = provisionerId, workerType: String!): WorkerType
+  workerTypes(provisionerId: String = provisionerId, connection: PageConnection, filter: JSON): WorkerTypesConnection
+  workerType(provisionerId: String = provisionerId, workerType: String!): WorkerType
 }
 
 type ProvisionersEdge implements Edge {
@@ -49,7 +49,7 @@ type ProvisionersConnection implements Connection {
 }
 
 extend type Query {
-  provisioner(provisionerId: ID!): Provisioner
+  provisioner(provisionerId: String!): Provisioner
   provisioners(connection: PageConnection, filter: JSON): ProvisionersConnection
 }
 

--- a/src/graphql/WorkerTypes.graphql
+++ b/src/graphql/WorkerTypes.graphql
@@ -14,18 +14,18 @@ type WorkerType {
   actions: [ProvisionerAction]!
 
   workers(
-    provisionerId: ID = provisionerId,
+    provisionerId: String = provisionerId,
     workerType: String = workerType,
     connection: PageConnection,
     filter: JSON
   ): WorkersCompactConnection
   worker(
-    provisionerId: ID = provisionerId,
+    provisionerId: String = provisionerId,
     workerType: String = workerType,
     workerGroup: String!,
     workerId: ID!
   ): Worker
-  pendingTasks(provisionerId: ID = provisionerId, workerType: String = workerType): Int!
+  pendingTasks(provisionerId: String = provisionerId, workerType: String = workerType): Int!
 }
 
 type WorkerTypesEdge implements Edge {
@@ -39,7 +39,7 @@ type WorkerTypesConnection implements Connection {
 }
 
 extend type Query {
-  workerType(provisionerId: ID!, workerType: String!): WorkerType
-  pendingTasks(provisionerId: ID!, workerType: String!): Int!
-  workerTypes(provisionerId: ID!, connection: PageConnection, filter: JSON): WorkerTypesConnection
+  workerType(provisionerId: String!, workerType: String!): WorkerType
+  pendingTasks(provisionerId: String!, workerType: String!): Int!
+  workerTypes(provisionerId: String!, connection: PageConnection, filter: JSON): WorkerTypesConnection
 }

--- a/src/graphql/Workers.graphql
+++ b/src/graphql/Workers.graphql
@@ -10,7 +10,7 @@ type WorkerCompact {
   firstClaim: DateTime!
   latestTask: LatestTask
   quarantineUntil: DateTime
-  provisionerId: ID!
+  provisionerId: String!
   workerType: String!
 }
 
@@ -75,13 +75,13 @@ type WorkersConnection implements Connection {
 }
 
 extend type Query {
-  worker(provisionerId: ID!, workerType: String!, workerGroup: String!, workerId: ID!): Worker
-  workers(provisionerId: ID!, workerType: String!, connection: PageConnection, filter: JSON, isQuarantined: Boolean): WorkersCompactConnection
+  worker(provisionerId: String!, workerType: String!, workerGroup: String!, workerId: ID!): Worker
+  workers(provisionerId: String!, workerType: String!, connection: PageConnection, filter: JSON, isQuarantined: Boolean): WorkersCompactConnection
 }
 
 extend type Mutation {
   quarantineWorker(
-    provisionerId: ID!,
+    provisionerId: String!,
     workerType: String!,
     workerGroup: String!,
     workerId: ID!,


### PR DESCRIPTION
`ID` signifies that it is not intended to be human‐readable. The provisioner ID is indeed readable so we should switch to `String`.