### PR TITLE
Add name to secret schema

### DIFF
--- a/src/graphql/Secrets.graphql
+++ b/src/graphql/Secrets.graphql
@@ -1,4 +1,5 @@
 type Secret {
+  name: String!
   secret: JSON!
   expires: DateTime!
 }

--- a/src/loaders/secrets.js
+++ b/src/loaders/secrets.js
@@ -13,7 +13,16 @@ export default ({ secrets }) => {
     };
   });
   const secret = new DataLoader(names =>
-    Promise.all(names.map(async name => secrets.get(name)))
+    Promise.all(
+      names.map(async name => {
+        const secret = await secrets.get(name);
+
+        return {
+          name,
+          ...secret,
+        };
+      })
+    )
   );
 
   return {


### PR DESCRIPTION
Particularly useful when mutating a secret and we want the mutation to return the secret name in the response.