### PR TITLE
Bug 1488526 - use taskcluster-lib-loader to load components

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -1,6 +1,7 @@
 module.exports = {
   use: [
     ['neutrino-preset-mozilla-frontend-infra/node', {
+      hot: false,
       babel: {
         plugins: [
           require.resolve('babel-plugin-transform-object-rest-spread'),
@@ -18,6 +19,6 @@ module.exports = {
           .test(/\.graphql$/)
           .use('raw')
             .loader(require.resolve('raw-loader'));
-    }
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sift": "^6.0.0",
     "source-map-support": "^0.5.4",
     "subscriptions-transport-ws": "^0.9.7",
-    "taskcluster-client": "^11.0.3"
+    "taskcluster-client": "^11.0.3",
+    "taskcluster-lib-loader": "^10.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import depthLimit from 'graphql-depth-limit';
 import { createComplexityLimitRule } from 'graphql-validation-complexity';
-import servers from './servers';
+import loader from 'taskcluster-lib-loader';
+import { createServer as httpServer } from 'http';
+import createApp from './servers/createApp';
 import createContext from './createContext';
 import createSchema from './createSchema';
 import createSubscriptionServer from './servers/createSubscriptionServer';
@@ -25,67 +27,78 @@ const port = +process.env.PORT || 3050;
   }
 });
 
-const pulseEngine = new PulseEngine({
-  connection: {
-    username: process.env.PULSE_USERNAME,
-    password: process.env.PULSE_PASSWORD,
-    hostname: process.env.PULSE_HOSTNAME,
-    vhost: process.env.PULSE_VHOST,
+const load = loader({
+  pulseEngine: {
+    requires: [],
+    setup: () =>
+      new PulseEngine({
+        connection: {
+          username: process.env.PULSE_USERNAME,
+          password: process.env.PULSE_PASSWORD,
+          hostname: process.env.PULSE_HOSTNAME,
+          vhost: process.env.PULSE_VHOST,
+        },
+      }),
+  },
+
+  schema: {
+    requires: [],
+    setup: () =>
+      createSchema({
+        typeDefs,
+        resolvers,
+        resolverValidationOptions: {
+          requireResolversForResolveType: false,
+        },
+        validationRules: [depthLimit(10), createComplexityLimitRule(1000)],
+      }),
+  },
+
+  context: {
+    requires: ['pulseEngine'],
+    setup: ({ pulseEngine }) => createContext({ pulseEngine }),
+  },
+
+  app: {
+    requires: ['context', 'schema'],
+    setup: ({ context, schema }) => createApp({ schema, context }),
+  },
+
+  server: {
+    requires: ['app', 'schema', 'context'],
+    setup: ({ app, schema, context }) => {
+      const server = httpServer(app);
+
+      createSubscriptionServer({
+        server, // this attaches itself directly to the server
+        schema,
+        context,
+        path: '/subscription',
+      });
+
+      return server;
+    },
+  },
+
+  devServer: {
+    requires: ['server'],
+    setup: async ({ server }) => {
+      await new Promise(resolve => server.listen(port, resolve));
+
+      /* eslint-disable no-console */
+      console.log(`\n\nWeb server running on port ${port}.`);
+      console.log(
+        `\nOpen the interactive GraphQL Playground and schema explorer in your browser at:
+        http://localhost:${port}/playground\n`
+      );
+      /* eslint-enable no-console */
+    },
   },
 });
-let schema;
-let context;
-let server;
-let app;
-let subscriptionServer;
-const load = () => {
-  schema = createSchema({
-    typeDefs,
-    resolvers,
-    resolverValidationOptions: {
-      requireResolversForResolveType: false,
-    },
-    validationRules: [depthLimit(10), createComplexityLimitRule(1000)],
+
+if (!module.parent) {
+  load('devServer').catch(err => {
+    console.log(err.stack); // eslint-disable-line no-console
+    process.exit(1);
   });
-  context = createContext({ pulseEngine });
-
-  const express = servers({ schema, context, server });
-
-  server = express.server; // eslint-disable-line prefer-destructuring
-  app = express.app; // eslint-disable-line prefer-destructuring
-  subscriptionServer = createSubscriptionServer({
-    server,
-    schema,
-    context,
-    path: '/subscription',
-  });
-};
-
-load();
-
-server.listen(port, () => {
-  /* eslint-disable no-console */
-  console.log(`\n\nWeb server running on port ${port}.`);
-  console.log(
-    `\nOpen the interactive GraphQL Playground and schema explorer in your browser at:
-    http://localhost:${port}/playground\n`
-  );
-  /* eslint-enable no-console */
-});
-
-if (module.hot) {
-  module.hot.accept(
-    [
-      './resolvers',
-      './graphql',
-      './servers/createSubscriptionServer',
-      './servers',
-    ],
-    () => {
-      subscriptionServer.close();
-      server.removeListener('request', app);
-      load();
-      server.on('request', app);
-    }
-  );
 }

--- a/src/servers/createApp.js
+++ b/src/servers/createApp.js
@@ -4,12 +4,10 @@ import cors from 'cors';
 import express from 'express';
 import playground from 'graphql-playground-middleware-express';
 import passport from 'passport';
-import { createServer as httpServer } from 'http';
-import { createServer as httpsServer } from 'https';
 import credentials from './credentials';
 import graphql from './graphql';
 
-export default ({ server, schema, context, https }) => {
+export default ({ schema, context }) => {
   const app = express();
 
   app.set('view engine', 'ejs');
@@ -48,8 +46,5 @@ export default ({ server, schema, context, https }) => {
     );
   }
 
-  return {
-    app,
-    server: server || https ? httpsServer(https, app) : httpServer(app),
-  };
+  return app;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,16 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+assume@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/assume/-/assume-1.5.2.tgz#057c5a2f33ce7d1ccd8d783db2d5d098cacdd111"
+  dependencies:
+    deep-eql "0.1.x"
+    fn.name "1.0.x"
+    object-inspect "1.0.x"
+    pathval "0.1.x"
+    pruddy-error "1.0.x"
+
 ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -2922,6 +2932,12 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
+deep-eql@0.1.x:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
+  dependencies:
+    type-detect "0.1.1"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -4092,6 +4108,10 @@ fluture@^8.0.2:
     inspect-f "^1.2.0"
     sanctuary-type-classes "^8.0.0"
     sanctuary-type-identifiers "^2.0.0"
+
+fn.name@1.0.x:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.0.1.tgz#8015ad149c1011a116cdb89eba4cc11d9039add8"
 
 follow-redirects@^1.0.0:
   version "1.5.5"
@@ -6627,6 +6647,10 @@ object-hash@^1.1.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
 
+object-inspect@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.0.2.tgz#a97885b553e575eb4009ebc09bdda9b1cd21979a"
+
 object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
@@ -7021,6 +7045,10 @@ path-type@^3.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
   dependencies:
     pify "^3.0.0"
+
+pathval@0.1.x:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-0.1.1.tgz#08f911cdca9cce5942880da7817bc0b723b66d82"
 
 pause@0.0.1:
   version "0.0.1"
@@ -7433,6 +7461,10 @@ proxy-addr@~2.0.3:
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
+pruddy-error@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pruddy-error/-/pruddy-error-1.0.2.tgz#b37ec1a38bf9107c0cdc5bc663d3d4e80354ae80"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -8900,6 +8932,17 @@ taskcluster-client@^11.0.3:
     superagent "~3.8.1"
     taskcluster-lib-urls "^10.0.0"
 
+taskcluster-lib-loader@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-loader/-/taskcluster-lib-loader-10.0.1.tgz#a6f785261dbad36a78198b5597bc95c21ab58b75"
+  dependencies:
+    assume "^1.5.2"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    lodash "^4.17.4"
+    promise "^8.0.1"
+    topo-sort "^1.0.0"
+
 taskcluster-lib-urls@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/taskcluster-lib-urls/-/taskcluster-lib-urls-10.0.0.tgz#ee4c687b4539171d8aef39b38a63c8b9bc82f82e"
@@ -9034,6 +9077,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+topo-sort@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/topo-sort/-/topo-sort-1.0.0.tgz#0ca3371b0963a4c4f955b3033abb130146eaa489"
+
 toposort@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
@@ -9087,6 +9134,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
 
 type-detect@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
This also turns off HMR, as it doesn't seem to work too well.  https://github.com/neutrinojs/neutrino/issues/1074 would help, particularly since startup of this service is so quick.

I considered adding support for `typed-env-config` here (reading config from `config.yml`), but I figured I should take baby steps.  We can figure that out when it is time to deploy this in Kubernetes.