### PR TITLE
Bug 1489305 - use neutrino-middleware-restart-server

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -13,6 +13,15 @@ module.exports = {
         },
       },
     }],
+    // replace start-server with restart-server
+    (neutrino) => {
+      neutrino.config.when(neutrino.options.command === 'start', config => {
+        config.plugins.delete('start-server');
+        neutrino.use(['neutrino-middleware-restart-server', {
+          name: 'index.js',
+        }]);
+      });
+    },
     (neutrino) => {
       neutrino.config.module
         .rule('graphql')

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "graphql-validation-complexity": "^0.2.3",
     "immutable": "^3.8.2",
     "iterall": "^1.2.2",
+    "neutrino-middleware-restart-server": "^1.0.1",
     "passport": "^0.4.0",
     "passport-github": "^1.1.0",
     "sift": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,6 +6371,10 @@ neo-async@^2.5.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.2.tgz#489105ce7bc54e709d736b195f82135048c50fcc"
 
+neutrino-middleware-restart-server@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/neutrino-middleware-restart-server/-/neutrino-middleware-restart-server-1.0.1.tgz#ab5b4197b973d602a204bb47916a5f57e1c045c6"
+
 neutrino-middleware-styleguidist@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/neutrino-middleware-styleguidist/-/neutrino-middleware-styleguidist-1.0.2.tgz#fac72b7d475f0e7737833f44ca66d5a1bb3e59a5"


### PR DESCRIPTION
The result is:

```
(v8.10.0) dustin@lamport ~/p/taskcluster-web-server [master*] $ yarn start
yarn run v1.9.4
$ neutrino start --require dotenv/config
✔ Build completed
Application started with no LOGIN_STRATEGIES defined.


Web server running on port 3050.

Open the interactive GraphQL Playground and schema explorer in your browser at:
        http://localhost:3050/playground

✔ Build completed
Application started with no LOGIN_STRATEGIES defined.


Web server running on port 3050.

Open the interactive GraphQL Playground and schema explorer in your browser at:
        http://localhost:3050/playground
```
etc.

Please also have a look at https://github.com/djmitche/neutrino-middleware-restart-server if you're willing :)