### PR TITLE
Increase body-parser limit

### DIFF
--- a/src/servers/createApp.js
+++ b/src/servers/createApp.js
@@ -18,7 +18,9 @@ export default async ({ cfg, schema, context }) => {
   app.use(compression());
   app.post(
     '/graphql',
-    bodyParser.graphql(),
+    bodyParser.graphql({
+      limit: '1mb',
+    }),
     graphql({
       schema,
       context,


### PR DESCRIPTION
GraphQL post requests for mutations can have a body bigger than the
default value of 100kb set by body-parser.