### PR TITLE
Handle task actions error

### DIFF
--- a/src/graphql/Tasks.graphql
+++ b/src/graphql/Tasks.graphql
@@ -154,7 +154,7 @@ type Task {
   status(taskId: ID = taskId): TaskStatus!
 
   # Actions exposed by the decision task defined in the public/actions.json artifact.
-  taskActions(taskGroupId: String = taskGroupId, filter: JSON): TaskActionsJson!
+  taskActions(taskGroupId: String = taskGroupId, filter: JSON): TaskActionsJson
 
   # Definition of the task group ID.
   taskGroup: Task

--- a/src/loaders/tasks.js
+++ b/src/loaders/tasks.js
@@ -38,15 +38,24 @@ export default ({ queue, index }) => {
           taskGroupId,
           'public/actions.json'
         );
-        const { body: raw } = await request
-          .get(url)
-          // retry on 5xx
-          .retry(2, (err, res) => res && res.status >= 500);
 
-        return {
-          ...raw,
-          actions: filter ? sift(filter, raw.actions) : raw.actions,
-        };
+        try {
+          const { body: raw } = await request
+            .get(url)
+            // retry on 5xx
+            .retry(2, (err, res) => res && res.status >= 500);
+
+          return {
+            ...raw,
+            actions: filter ? sift(filter, raw.actions) : raw.actions,
+          };
+        } catch (e) {
+          if (e.status === 404) {
+            return null;
+          }
+
+          return e;
+        }
       })
     )
   );


### PR DESCRIPTION
When a task is first created, task actions don't seem to be present. Instead of returning an error, we can simply return `null`.