### PR TITLE
Bug 1495918 - use `NO_TEST_SKIP: "true"` rather than `NO_TEST_SKIP: true` in yaml files

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,7 +15,7 @@ tasks:
         - secrets:get:project/taskcluster/testing/taskcluster-web-server
     payload:
       env:
-        NO_TEST_SKIP: true
+        NO_TEST_SKIP: "true"
       features:
         taskclusterProxy: true
       maxRunTime: 3600


### PR DESCRIPTION
In task payloads, environment variables must be strings, not booleans.

This fixes `NO_TEST_SKIP` environment variable in the task definition to be a string.

See [bug 1495918](https://bugzilla.mozilla.org/show_bug.cgi?id=1495918#c6) for context.