### PR TITLE
Bug 1490723 - produce both "events" and "messages"

### DIFF
--- a/src/PulseEngine/EventIterator.js
+++ b/src/PulseEngine/EventIterator.js
@@ -1,0 +1,31 @@
+import { $$asyncIterator } from 'iterall';
+
+export default class EventIterator {
+  /**
+   * Wrapper around a PulseIterator that yields pulse messages, transforming
+   * them to {[eventName]: payload} format as expected by purpose-specific
+   * subscriptions
+   */
+  constructor(messageIterator, eventName) {
+    this.eventName = eventName;
+    this.messageIterator = messageIterator;
+  }
+
+  async next() {
+    const { value, done } = await this.messageIterator.next();
+    const event = { [this.eventName]: value.payload };
+    return { value: event, done };
+  }
+
+  return() {
+    return this.messageIterator.return();
+  }
+
+  throw(error) {
+    return this.messageIterator.throw(error);
+  }
+
+  [$$asyncIterator]() {
+    return this;
+  }
+}

--- a/src/PulseEngine/MessageIterator.js
+++ b/src/PulseEngine/MessageIterator.js
@@ -1,0 +1,31 @@
+import { $$asyncIterator } from 'iterall';
+
+export default class MessageIterator {
+  /**
+   * Wrapper around a PulseIterator that yields pulse messages, transforming
+   * them to {[eventName]: {payload, ..}} format as expected by pulse-messages
+   * subscriptions
+   */
+  constructor(messageIterator, eventName) {
+    this.eventName = eventName;
+    this.messageIterator = messageIterator;
+  }
+
+  async next() {
+    const { value, done } = await this.messageIterator.next();
+    const event = { [this.eventName]: value };
+    return { value: event, done };
+  }
+
+  return() {
+    return this.messageIterator.return();
+  }
+
+  throw(error) {
+    return this.messageIterator.throw(error);
+  }
+
+  [$$asyncIterator]() {
+    return this;
+  }
+}

--- a/src/graphql/PulseMessages.graphql
+++ b/src/graphql/PulseMessages.graphql
@@ -1,8 +1,30 @@
+# Subscription to pulse messages: listen for messages with routes matching
+# `pattern` (including `#` and `*` AMQP wildcards) on `exchange`.
 input PulseSubscription {
   exchange: String!
   pattern: String!
 }
 
+# An arbitrary pulse message, with some metadata but with an opaque payload
+type PulseMessage {
+  # The payload of the message (an arbitrary JSON blob)
+  payload: JSON!
+
+  # The exchange to which this message was published
+  exchange: String!
+
+  # The routing key with which this message was published
+  routingKey: String!
+
+  # True if this is not the first delivery of this message (if processing
+  # failed the first time)
+  redelivered: Boolean!
+
+  # Other routing keys this message was cc'd to
+  cc: [String]!
+}
+
 extend type Subscription {
-  pulseMessages(subscriptions: [PulseSubscription]!): JSON
+  # Subscribe to arbitrary pulse messages
+  pulseMessages(subscriptions: [PulseSubscription]!): PulseMessage
 }

--- a/src/resolvers/Artifacts.js
+++ b/src/resolvers/Artifacts.js
@@ -23,7 +23,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.artifactCreated(routingKey);
 
-        return pulseEngine.asyncIterator('artifactsCreated', {
+        return pulseEngine.eventIterator('artifactsCreated', {
           [binding.routingKeyPattern]: [binding.exchange],
         });
       },

--- a/src/resolvers/PulseMessages.js
+++ b/src/resolvers/PulseMessages.js
@@ -2,7 +2,7 @@ export default {
   Subscription: {
     pulseMessages: {
       subscribe(parent, { subscriptions }, { pulseEngine }) {
-        return pulseEngine.asyncIterator('pulseMessages', subscriptions);
+        return pulseEngine.messageIterator('pulseMessages', subscriptions);
       },
     },
   },

--- a/src/resolvers/Tasks.js
+++ b/src/resolvers/Tasks.js
@@ -123,7 +123,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskDefined(routingKey);
 
-        return pulseEngine.asyncIterator('tasksDefined', [
+        return pulseEngine.eventIterator('tasksDefined', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -136,7 +136,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskPending(routingKey);
 
-        return pulseEngine.asyncIterator('tasksPending', [
+        return pulseEngine.eventIterator('tasksPending', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -149,7 +149,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskRunning(routingKey);
 
-        return pulseEngine.asyncIterator('tasksRunning', [
+        return pulseEngine.eventIterator('tasksRunning', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -162,7 +162,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskCompleted(routingKey);
 
-        return pulseEngine.asyncIterator('tasksCompleted', [
+        return pulseEngine.eventIterator('tasksCompleted', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -175,7 +175,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskFailed(routingKey);
 
-        return pulseEngine.asyncIterator('tasksFailed', [
+        return pulseEngine.eventIterator('tasksFailed', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -188,7 +188,7 @@ export default {
         const routingKey = { taskGroupId };
         const binding = clients.queueEvents.taskException(routingKey);
 
-        return pulseEngine.asyncIterator('tasksException', [
+        return pulseEngine.eventIterator('tasksException', [
           {
             exchange: binding.exchange,
             pattern: binding.routingKeyPattern,
@@ -204,7 +204,7 @@ export default {
       ) {
         const routingKey = { taskGroupId };
 
-        return pulseEngine.asyncIterator(
+        return pulseEngine.eventIterator(
           'tasksSubscriptions',
           subscriptions.map(eventName => {
             const method = eventName.replace('tasks', 'task');


### PR DESCRIPTION
Events are the purpose-specific things with type information, while
messages are generic Pulse messages.  The pulse messages have a schema
but a very general one, with no specific form for the payload.