### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start


### PR DESCRIPTION
I'm trying to run this repo via taskcluster-builder. My `build.yml` file is:

```yml
repositories:
  - name: 'web'
    kind: 'service'
    service:
      buildtype: 'tools-ui'
      node: '10'
    source: 'https://github.com/taskcluster/taskcluster-web.git'
    docs: false
  - name: 'web-server'
    kind: 'service'
    service:
      buildtype: 'heroku-buildpack'
      stack: 'heroku-16'
      buildpack: 'https://github.com/heroku/heroku-buildpack-nodejs#v83'
    source: 'https://github.com/taskcluster/taskcluster-web-server.git'
    docs: 'generated'
```

Running taskcluster-builder throws:

```bash
✖ Service web-server - Compile (Error: Service web-server has no Procfile)
61% finished
Error: Service web-server has no Procfile
    at Object.run (/Users/haali/Documents/Mozilla/projects/taskcluster-builder/src/build/service/heroku-buildpack.js:149:15)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
``` 

I believe this would fix the issue.