### PR TITLE
Increase query limit

### DIFF
--- a/src/ConnectionLoader.js
+++ b/src/ConnectionLoader.js
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 
-const LIMIT = 100;
+const LIMIT = 1000;
 const FIRST = '$$FIRST$$';
 
 export default class ConnectionLoader {

--- a/src/graphql/Artifacts.graphql
+++ b/src/graphql/Artifacts.graphql
@@ -84,7 +84,7 @@ extend type Query {
   # Returns a list of artifacts and associated metadata for a particular task run.
   # As a task run may have many artifacts, this may return cursors to page through artifacts.
   # To continue listing artifacts, use the returned connection with the desired
-  # front or back cursor. This query can return a maximum of up to 100 artifacts in a single page.
+  # front or back cursor. This query can return a maximum of up to 1000 artifacts in a single page.
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
@@ -93,7 +93,7 @@ extend type Query {
   # Returns a list of the artifacts and associated metadata for latest run of a task.
   # As a task run may have many artifacts, this may return cursors to page through artifacts.
   # To continue listing artifacts, use the returned connection with the desired
-  # front or back cursor. This query can return a maximum of up to 100 artifacts in a single page.
+  # front or back cursor. This query can return a maximum of up to 1000 artifacts in a single page.
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.

--- a/src/graphql/TaskRuns.graphql
+++ b/src/graphql/TaskRuns.graphql
@@ -85,7 +85,7 @@ type TaskRun {
   # Returns a list of artifacts and associated metadata for this task run.
   # As a task run may have many artifacts, this may return cursors to page through artifacts.
   # To continue listing artifacts, use the returned connection with the desired
-  # front or back cursor. This query can return a maximum of up to 100 artifacts in a single page.
+  # front or back cursor. This query can return a maximum of up to 1000 artifacts in a single page.
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.

--- a/src/graphql/Tasks.graphql
+++ b/src/graphql/Tasks.graphql
@@ -162,7 +162,7 @@ type Task {
   # Returns a list of the artifacts and associated metadata for latest run of this task.
   # As a task run may have many artifacts, this may return cursors to page through artifacts.
   # To continue listing artifacts, use the returned connection with the desired
-  # front or back cursor. This query can return a maximum of up to 100 artifacts in a single page.
+  # front or back cursor. This query can return a maximum of up to 1000 artifacts in a single page.
   # It **may return less**, even if more artifacts are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.
@@ -367,7 +367,7 @@ extend type Query {
   # As a task group may contain an unbounded number of tasks,
   # this may return cursors to page through tasks. To continue listing tasks,
   # use the returned connection with the desired front or back cursor.
-  # This query can return a maximum of up to 100 tasks in a single page.
+  # This query can return a maximum of up to 1000 tasks in a single page.
   # It **may return less**, even if more tasks are available.
   # It may also return a page connection even though there are no more results.
   # Use the connection limit to specify smaller page sizes.


### PR DESCRIPTION
Fetching a task graph of 7000 tasks takes too long when the response
limit is set to 100. Let's increase that number to 1000.