### PR TITLE
Handle artifact url when private

### DIFF
--- a/src/loaders/artifacts.js
+++ b/src/loaders/artifacts.js
@@ -39,6 +39,13 @@ export default ({ queue }, isAuthed, rootUrl) => {
       };
     }
 
+    if (!isPublic && !isAuthed) {
+      return {
+        ...artifact,
+        url: null,
+      }
+    }
+
     return {
       ...artifact,
       url: hasRunId


### PR DESCRIPTION
Attempting to build a signed url for a private artifact when credentials
are not there throws an error. The is commit makes sure an empty url is
returned.

Fixes #72.